### PR TITLE
Message is treated as an associative array elsewhere, so json_decode nee...

### DIFF
--- a/src/gburtini/ACL/User.php
+++ b/src/gburtini/ACL/User.php
@@ -172,7 +172,7 @@ class User {
          throw new RuntimeException("Cowardly refusing to continue decryption when Rijndael failed.");
       $plaintext_dec = rtrim($plaintext_dec, "\0\4");	// this is scary, but mcrypt_encrypt padded with zeros.
 
-      return json_decode($plaintext_dec);
+      return json_decode($plaintext_dec, true);
   }
 
   /*


### PR DESCRIPTION
Message is treated as an associative array elsewhere, so json_decode needs to be told to create it as such.
